### PR TITLE
Conexão do perfil com Backend

### DIFF
--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -33,10 +33,16 @@ class ApiClient {
     return this.request<T>(path, auth, { method: "GET" });
   }
 
-
   public post<T = any>(path: string, auth: Auth, body: any) {
     return this.request<T>(path, auth, {
       method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  public put<T = any>(path: string, auth: Auth, body: any) {
+    return this.request<T>(path, auth, {
+      method: "PUT",
       body: JSON.stringify(body),
     });
   }


### PR DESCRIPTION
Foram implementadas as conexões entre o backend e o frontend, para que as informações dos usuário sejam puxadas corretamente. Caso você entre no perfil de um usuário pela página de membros, os dados desse usuário serão inseridos nos campos correspondentes dentro da página. O mesmo ocorre caso o usuário entre no próprio perfil através do botão do profile. Vale ressaltar que se o usuário entrar na própria página através da página de membros, o código identifica que o perfil é próprio e habilita modificações. Por fim, as alterações feitas na página do usuário logado são enviadas ao banco de dados. Para que essa última implementação seja feita, foi necessário adicionar um novo método à classe ApiClient, possibilitando que o método 'PUT' fosse utilizado. Outra observação importante, quando comecei a fazer as requisições, percebi um erro nas rotas de '/users/' no qual não era possível acessar a rota '/me'. Para resolver o problema foi necessário modificar a ordem das rotas no código do backend, iserindo a rota '/me' antes da rota '/:id' que esperava um id de usuário.